### PR TITLE
タスクカードの締め切り書式変更に伴いJSON操作を修正

### DIFF
--- a/GetTask.gs
+++ b/GetTask.gs
@@ -28,9 +28,12 @@ const getTommorrow = () => {
 const getStartDate = (task) => {
 
   try {
-    const getTaskDateString = task["properties"]["開始日"]["date"]["start"];
-    const taskStartDate = new Date(getTaskDateString)
-    return Utilities.formatDate( taskStartDate, 'Asia/Tokyo', 'yyyy-MM-dd');  
+    const getTaskDateString = task["properties"]["開始と期限"]["date"]["start"];
+    const taskstartindex = getTaskDateString.indexOf(".")
+    const slicestartstr = getTaskDateString.slice(0,taskstartindex)
+
+    const taskStartDate = new Date(slicestartstr)
+    return Utilities.formatDate( taskStartDate, 'Asia/Tokyo', 'yyyy/MM/dd HH:mm');  
   }
   catch(e){
     console.log("タスクの開始日が記入されてないです getStartDate");
@@ -42,9 +45,13 @@ const getStartDate = (task) => {
 const getDeadlineDate = (task) => {
 
   try {
-    const getTaskDateString = task["properties"]["締め切り"]["date"]["start"];
-    const taskDeadlineDate = new Date(getTaskDateString)
-    return Utilities.formatDate( taskDeadlineDate, 'Asia/Tokyo', 'yyyy-MM-dd');
+    const taskenddate = task["properties"]["開始と期限"]["date"]["end"]
+    const taskendindex= taskenddate.indexOf(".")
+    const sliceendstr = taskenddate.slice(0,taskendindex)
+
+    const taskDeadlineDate = new Date(sliceendstr)
+    console.log("ハバ卒：" + taskDeadlineDate)
+    return Utilities.formatDate( taskDeadlineDate, 'Asia/Tokyo', 'yyyy/MM/dd HH:mm');
   }
   catch(e){
     console.log("タスクの締め切りが記入されてない");

--- a/NotionGmail.gs
+++ b/NotionGmail.gs
@@ -31,6 +31,7 @@ class NotionTaskGmail {
 
     for(let task of tasks)
     {
+      //jsoncheck(task)
       donceclass.varidate(task,this)
     }
 

--- a/NotionJSONCheck.gs
+++ b/NotionJSONCheck.gs
@@ -1,3 +1,20 @@
 function jsoncheck(task) {
   console.log(task);
+  const getTaskDateString = task["properties"]["開始と期限"]["date"]["start"];
+  const taskstartindex = getTaskDateString.indexOf(".")
+  const slicestartstr = getTaskDateString.slice(0,taskstartindex)
+  const startDateSplit_colon = slicestartstr.replaceAll(":","-")
+  const startDateSplit_colon_T = startDateSplit_colon.replaceAll("T","-")
+  console.log("ハセシン："  + startDateSplit_colon_T);
+
+
+  const taskenddate = task["properties"]["開始と期限"]["date"]["end"]
+  const taskendindex= taskenddate.indexOf(".")
+  const sliceendstr = taskenddate.slice(0,taskendindex)
+  const endDateSplit_colon = sliceendstr.replaceAll(":","-")
+  const endDateSplit_colon_T = endDateSplit_colon.replaceAll("T","-")
+  console.log("トワ：" + endDateSplit_colon_T);
+
+  exit(1);
 }
+


### PR DESCRIPTION
- タスクカード締め切りの書式を変更　締め切りを削除　→　開始と期限に共通化
- メール通知の日時の書式を変更　yyyy-MM-dd → yyyy/MM/dd HH:mm